### PR TITLE
Rename `ITC_config.h` to `ITC_Config.h`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [Meson built-in options](https://mesonbuild.com/Builtin-options.html) for mo
 
 libitc strives to be flexible and allows turning on/off optional features. This allows you to alter/extend its feature set depending on your needs.
 
-See [`ITC_config.h`](./libitc/include/ITC_config.h) for all available options.
+See [`ITC_Config.h`](./libitc/include/ITC_Config.h) for all available options.
 
 You can modify the header file directly to change the default configuration, or you can provide alternative values via `CFLAGS` or the [builtin `c_args` Meson option](https://mesonbuild.com/Builtin-options.html#:~:text=Description-,c_args,-free%2Dform%20comma) during the [build configuration](#build-configuration) stage.
 
@@ -65,7 +65,7 @@ The [feature configuration](#feature-configuration) allows for 3 types of memory
 
 1. Dynamic memory (HEAP), using standard `malloc` and `free` libc calls
 2. Static memory, using global static arrays.
-> :warning: Static memory allocation is **not** thread-safe. See [`ITC_config.h`](./libitc/include/ITC_config.h) and [`ITC_memory.h`](./libitc/include/ITC_Memory.h) for more information.
+> :warning: Static memory allocation is **not** thread-safe. See [`ITC_Config.h`](./libitc/include/ITC_Config.h) and [`ITC_Memory.h`](./libitc/include/ITC_Memory.h) for more information.
 3. Custom `malloc` and `free` implementations
 
 #### Compilation

--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -10,7 +10,7 @@
 #include "ITC_Event.h"
 #include "ITC_Event_package.h"
 #include "ITC_Event_private.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #include "ITC_SerDes_private.h"
 #include "ITC_SerDes_Util_package.h"

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -10,7 +10,7 @@
 #include "ITC_Id.h"
 #include "ITC_Id_package.h"
 #include "ITC_Id_private.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #include "ITC_SerDes_private.h"
 #include "ITC_SerDes_Util_package.h"

--- a/libitc/ITC_Port.c
+++ b/libitc/ITC_Port.c
@@ -7,7 +7,7 @@
  * https://www.gnu.org/licenses/agpl-3.0.en.html
  *
  */
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #if ITC_CONFIG_MEMORY_ALLOCATION_TYPE != ITC_MEMORY_ALLOCATION_TYPE_CUSTOM
 #include "ITC_Port.h"

--- a/libitc/ITC_Port_private.h
+++ b/libitc/ITC_Port_private.h
@@ -10,7 +10,7 @@
 #ifndef ITC_PORT_PRIVATE_H_
 #define ITC_PORT_PRIVATE_H_
 
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #if ITC_CONFIG_MEMORY_ALLOCATION_TYPE == ITC_MEMORY_ALLOCATION_TYPE_STATIC
 

--- a/libitc/ITC_Stamp.c
+++ b/libitc/ITC_Stamp.c
@@ -8,7 +8,7 @@
  *
  */
 #include "ITC_Stamp.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 #include "ITC_SerDes.h"
 
 #if !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API)

--- a/libitc/include/ITC_Config.h
+++ b/libitc/include/ITC_Config.h
@@ -1,5 +1,5 @@
 /**
- * @file ITC_config.h
+ * @file ITC_Config.h
  * @brief Configuration options for the ITC implementation
  *
  * @copyright Copyright (c) 2024 libitc project. Released under AGPL-3.0

--- a/libitc/include/ITC_Event.h
+++ b/libitc/include/ITC_Event.h
@@ -10,7 +10,7 @@
 #ifndef ITC_EVENT_H_
 #define ITC_EVENT_H_
 
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #include <stdint.h>
 

--- a/libitc/include/ITC_Event_prototypes.h
+++ b/libitc/include/ITC_Event_prototypes.h
@@ -10,7 +10,7 @@
 #ifndef ITC_EVENT_PROTOTYPES_H_
 #define ITC_EVENT_PROTOTYPES_H_
 
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #if ITC_CONFIG_ENABLE_EXTENDED_API
 

--- a/libitc/include/ITC_Id_prototypes.h
+++ b/libitc/include/ITC_Id_prototypes.h
@@ -10,7 +10,7 @@
 #ifndef ITC_ID_PROTOTYPES_H_
 #define ITC_ID_PROTOTYPES_H_
 
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #if ITC_CONFIG_ENABLE_EXTENDED_API
 

--- a/libitc/include/ITC_Port.h
+++ b/libitc/include/ITC_Port.h
@@ -11,7 +11,7 @@
 #define ITC_PORT_H_
 
 #include "ITC_Status.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 #include "ITC_Event.h"
 #include "ITC_Id.h"
 #include "ITC_Stamp.h"
@@ -70,7 +70,7 @@ extern uint32_t gu32_ItcStampNodeAllocationArrayLength;
  * Initialises the port logic for allocating/deallocating ITC nodes.
  *
  * @note This function will not be called automatically. It is the responsibility
- * of the user to call it when needed/appropriate. See `ITC_config.h` for more
+ * of the user to call it when needed/appropriate. See `ITC_Config.h` for more
  * information.
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success
@@ -83,7 +83,7 @@ ITC_Status_t ITC_Port_init(void);
  * Finalises the port logic for allocating/deallocating ITC nodes.
  *
  * @note This function will not be called automatically. It is the responsibility
- * of the user to call it when needed/appropriate. See `ITC_config.h` for more
+ * of the user to call it when needed/appropriate. See `ITC_Config.h` for more
  * infosrmation.
  * @return `ITC_Status_t` The status of the operation
  * @retval `ITC_STATUS_SUCCESS` on success

--- a/libitc/include/ITC_SerDes.h
+++ b/libitc/include/ITC_SerDes.h
@@ -13,7 +13,7 @@
 
 #include "ITC_Stamp.h"
 #include "ITC_Status.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #if ITC_CONFIG_ENABLE_EXTENDED_API
 #include "ITC_Id.h"

--- a/libitc/include/ITC_Stamp_prototypes.h
+++ b/libitc/include/ITC_Stamp_prototypes.h
@@ -12,7 +12,7 @@
 
 #include "ITC_Stamp.h"
 #include "ITC_Status.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 /******************************************************************************
  * Functions

--- a/libitc/package-include/ITC_Event_package.h
+++ b/libitc/package-include/ITC_Event_package.h
@@ -14,7 +14,7 @@
 
 #include "ITC_Id.h"
 #include "ITC_Status.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #include <stdbool.h>
 

--- a/libitc/package-include/ITC_Id_package.h
+++ b/libitc/package-include/ITC_Id_package.h
@@ -12,7 +12,7 @@
 
 #include "ITC_Id.h"
 #include "ITC_Status.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 /******************************************************************************
  * Functions

--- a/libitc/package-include/ITC_SerDes_package.h
+++ b/libitc/package-include/ITC_SerDes_package.h
@@ -11,7 +11,7 @@
 #ifndef ITC_SERDES_PACKAGE_H_
 #define ITC_SERDES_PACKAGE_H_
 
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #if !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API)
 #include "ITC_Status.h"

--- a/tests/include/ITC_TestUtil.h
+++ b/tests/include/ITC_TestUtil.h
@@ -14,7 +14,7 @@
 #include "ITC_Event.h"
 #include "ITC_Stamp.h"
 #include "ITC_Status.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #include <stdint.h>
 

--- a/tests/include/ITC_Test_package.h
+++ b/tests/include/ITC_Test_package.h
@@ -12,7 +12,7 @@
 
 #include "ITC_Event_Test_package.h"
 #include "ITC_Id_Test_package.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 /******************************************************************************
  * Defines

--- a/tests/normal/ITC_SerDes_Test.c
+++ b/tests/normal/ITC_SerDes_Test.c
@@ -10,7 +10,7 @@
  */
 #include "ITC_SerDes.h"
 #include "ITC_SerDes_Test.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #if !(ITC_CONFIG_ENABLE_SERIALISE_TO_STRING_API && ITC_CONFIG_ENABLE_EXTENDED_API)
 #include "ITC_SerDes_package.h"

--- a/tests/normal/ITC_Stamp_Test.c
+++ b/tests/normal/ITC_Stamp_Test.c
@@ -16,7 +16,7 @@
 
 #include "ITC_Test_package.h"
 #include "ITC_TestUtil.h"
-#include "ITC_config.h"
+#include "ITC_Config.h"
 
 #if ITC_CONFIG_MEMORY_ALLOCATION_TYPE == ITC_MEMORY_ALLOCATION_TYPE_STATIC
 #include "ITC_Port.h"


### PR DESCRIPTION
Renames `ITC_config.h` to `ITC_Config.h` to improve consistency between header names.