### PR TITLE
Do not compile `ITC_Event_join`, `ITC_Id_sum` and `ITC_Id_split` when extened API support is disabled

### DIFF
--- a/libitc/ITC_Event.c
+++ b/libitc/ITC_Event.c
@@ -2279,6 +2279,8 @@ ITC_Status_t ITC_Event_validate(
     return validateEvent(pt_Event, true);
 }
 
+#if ITC_CONFIG_ENABLE_EXTENDED_API
+
 /******************************************************************************
  * Join two existing Events into a single Event
  ******************************************************************************/
@@ -2295,20 +2297,10 @@ ITC_Status_t ITC_Event_join(
     {
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
+    else
     {
-        t_Status = validateEvent(*ppt_Event, true);
-    }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        t_Status = validateEvent(*ppt_OtherEvent, true);
-    }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        t_Status = joinEventE(*ppt_Event, *ppt_OtherEvent, &pt_JoinedEvent);
+        t_Status = ITC_Event_joinConst(
+            *ppt_Event, *ppt_OtherEvent, &pt_JoinedEvent);
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
@@ -2334,6 +2326,8 @@ ITC_Status_t ITC_Event_join(
 
     return t_Status;
 }
+
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 
 /******************************************************************************
  * Join two Events similar to ::ITC_Event_join() but do not modify the source Events

--- a/libitc/ITC_Id.c
+++ b/libitc/ITC_Id.c
@@ -1386,6 +1386,8 @@ ITC_Status_t ITC_Id_validate(
     return validateId(pt_Id, true);
 }
 
+#if ITC_CONFIG_ENABLE_EXTENDED_API
+
 /******************************************************************************
  * Split an existing ITC ID into two distinct (non-overlaping) ITC IDs
  ******************************************************************************/
@@ -1395,22 +1397,16 @@ ITC_Status_t ITC_Id_split(
     ITC_Id_t **ppt_OtherId
 )
 {
-    ITC_Status_t t_Status = ITC_STATUS_SUCCESS; /* The current status */
+    ITC_Status_t t_Status; /* The current status */
     ITC_Id_t *pt_NewId = NULL;
 
     if (!ppt_Id || !ppt_OtherId)
     {
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
+    else
     {
-        t_Status = validateId(*ppt_Id, true);
-    }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        t_Status = splitIdI(*ppt_Id, &pt_NewId, ppt_OtherId);
+        t_Status = ITC_Id_splitConst(*ppt_Id, &pt_NewId, ppt_OtherId);
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
@@ -1452,20 +1448,9 @@ ITC_Status_t ITC_Id_sum(
     {
         t_Status = ITC_STATUS_INVALID_PARAM;
     }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
+    else
     {
-        t_Status = validateId(*ppt_Id, true);
-    }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        t_Status = validateId(*ppt_OtherId, true);
-    }
-
-    if (t_Status == ITC_STATUS_SUCCESS)
-    {
-        t_Status = sumIdI(*ppt_Id, *ppt_OtherId, &pt_SummedId);
+        t_Status = ITC_Id_sumConst(*ppt_Id, *ppt_OtherId, &pt_SummedId);
     }
 
     if (t_Status == ITC_STATUS_SUCCESS)
@@ -1491,6 +1476,8 @@ ITC_Status_t ITC_Id_sum(
 
     return t_Status;
 }
+
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 
 /******************************************************************************
  * Split an ID similar to ::ITC_Id_split() but do not modify the source ID

--- a/libitc/package-include/ITC_Event_package.h
+++ b/libitc/package-include/ITC_Event_package.h
@@ -74,22 +74,6 @@ ITC_Status_t ITC_Event_validate(
     const ITC_Event_t *const pt_Event
 );
 
-/**
- * @brief Join two existing Events into a single Event
- *
- * @note On success, `ppt_OtherEvent` will be automatically deallocated to
- * prevent it from being used again accidentally (as well as to reduce developer
- * cleanup burden)
- * @param ppt_Event (in) The first existing Event. (out) The joined Event
- * @param ppt_OtherEvent (in) The second existing Event. (out) NULL
- * @return `ITC_Status_t` The status of the operation
- * @retval `ITC_STATUS_SUCCESS` on success
- */
-ITC_Status_t ITC_Event_join(
-    ITC_Event_t **ppt_Event,
-    ITC_Event_t **ppt_OtherEvent
-);
-
 #endif /* !ITC_CONFIG_ENABLE_EXTENDED_API */
 
 /**

--- a/libitc/package-include/ITC_Id_package.h
+++ b/libitc/package-include/ITC_Id_package.h
@@ -83,35 +83,6 @@ ITC_Status_t ITC_Id_validate(
     const ITC_Id_t *const pt_Id
 );
 
-/**
- * @brief Split an existing ITC ID into two distinct (non-overlaping) ITC IDs
- *
- * @param ppt_Id (in) The existing ID. (out) The first split ID
- * @param ppt_OtherId (out) The second split ID
- * @return `ITC_Status_t` The status of the operation
- * @retval `ITC_STATUS_SUCCESS` on success
- */
-ITC_Status_t ITC_Id_split(
-    ITC_Id_t **ppt_Id,
-    ITC_Id_t **ppt_OtherId
-);
-
-/**
- * @brief Sum two existing IDs into a single ID
- *
- * @note On success, `ppt_OtherId` will be automatically deallocated to prevent
- * it from being used again accidentally (as well as to reduce developer
- * cleanup burden)
- * @param ppt_Id (in) The first existing ID. (out) The summed ID
- * @param ppt_OtherId (in) The second existing ID. (out) NULL
- * @return `ITC_Status_t` The status of the operation
- * @retval `ITC_STATUS_SUCCESS` on success
- */
-ITC_Status_t ITC_Id_sum(
-    ITC_Id_t **ppt_Id,
-    ITC_Id_t **ppt_OtherId
-);
-
 #endif /* !ITC_CONFIG_ENABLE_EXTENDED_API */
 
 /**

--- a/tests/mocked/ITC_Event_Test.c
+++ b/tests/mocked/ITC_Event_Test.c
@@ -196,6 +196,8 @@ void ITC_Event_Test_joinedEventIsDestroyedOnFailure(void)
         &rt_CopiedLeafEvent[2],
     };
 
+    ITC_Event_t *pt_ResultEvent;
+
     /* Setup expectations */
 
     /* Expect parent event copy */
@@ -291,13 +293,14 @@ void ITC_Event_Test_joinedEventIsDestroyedOnFailure(void)
 
     /* Test failing to join the Events */
     TEST_FAILURE(
-        ITC_Event_join(&gpt_ParentEvent, &gpt_LeafEvent),
+        ITC_Event_joinConst(gpt_ParentEvent, gpt_LeafEvent, &pt_ResultEvent),
         ITC_STATUS_FAILURE);
 }
 
 /* Test successful joining of two Events is properly cleaned up */
 void ITC_Event_Test_joinOriginalAndCopiedEventsAreDestroyedOnSucess(void)
 {
+#if ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Event_t t_OtherEvent = gt_LeafNode;
     ITC_Event_t *pt_OtherEvent = &t_OtherEvent;
 
@@ -344,6 +347,9 @@ void ITC_Event_Test_joinOriginalAndCopiedEventsAreDestroyedOnSucess(void)
     /* Test joining the Events */
     TEST_SUCCESS(ITC_Event_join(&gpt_LeafEvent, &pt_OtherEvent));
     TEST_ITC_EVENT_IS_LEAF_N_EVENT(gpt_LeafEvent, 0);
+#else
+    TEST_IGNORE_MESSAGE("Extended API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test failed maximise an Event is properly recovered from */

--- a/tests/mocked/ITC_Id_Test.c
+++ b/tests/mocked/ITC_Id_Test.c
@@ -161,15 +161,17 @@ void ITC_Id_Test_clonedIdIsDestroyedOnFailure(void)
 }
 
 /* Test failed splitting of an ID is properly cleaned up */
-void ITC_Id_Test_splitIdsAreDestroyedOnFailure(void)
+void ITC_Id_Test_splitConstIdsAreDestroyedOnFailure(void)
 {
-    ITC_Id_t *pt_OtherId;
 
     ITC_Id_t t_NewId1 = {0};
     ITC_Id_t *pt_NewId1 = &t_NewId1;
 
     ITC_Id_t t_NewId2 = {0};
     ITC_Id_t *pt_NewId2 = &t_NewId2;
+
+    ITC_Id_t *pt_ResultId1 = NULL;
+    ITC_Id_t *pt_ResultId2 = NULL;
 
     /* Setup expectations */
     ITC_Port_malloc_ExpectAndReturn(
@@ -189,9 +191,10 @@ void ITC_Id_Test_splitIdsAreDestroyedOnFailure(void)
     /* Test failing to split a null ID */
     gpt_LeafId->b_IsOwner = false;
     TEST_FAILURE(
-        ITC_Id_split(
-            &gpt_LeafId,
-            &pt_OtherId),
+        ITC_Id_splitConst(
+            gpt_LeafId,
+            &pt_ResultId1,
+            &pt_ResultId2),
         ITC_STATUS_FAILURE);
 
     /* Setup expectations */
@@ -212,9 +215,10 @@ void ITC_Id_Test_splitIdsAreDestroyedOnFailure(void)
     /* Test failing to split a seed ID */
     gpt_LeafId->b_IsOwner = true;
     TEST_FAILURE(
-        ITC_Id_split(
-            &gpt_LeafId,
-            &pt_OtherId),
+        ITC_Id_splitConst(
+            gpt_LeafId,
+            &pt_ResultId1,
+            &pt_ResultId2),
         ITC_STATUS_FAILURE);
 
     /* Setup expectations */
@@ -243,15 +247,17 @@ void ITC_Id_Test_splitIdsAreDestroyedOnFailure(void)
 
     /* Test failing to split a (0, 1) ID */
     TEST_FAILURE(
-        ITC_Id_split(
-            &gpt_ParentId,
-            &pt_OtherId),
+        ITC_Id_splitConst(
+            gpt_ParentId,
+            &pt_ResultId1,
+            &pt_ResultId2),
         ITC_STATUS_FAILURE);
 }
 
 /* Test original ID is destroyed when split */
 void ITC_Id_Test_splitIdOriginalIdIsDestroyedOnSuccess(void)
 {
+#if ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Id_t *pt_OtherId;
 
     ITC_Id_t t_NewId1 = {0};
@@ -279,6 +285,9 @@ void ITC_Id_Test_splitIdOriginalIdIsDestroyedOnSuccess(void)
     /* Test splitting the ID */
     gpt_LeafId->b_IsOwner = false;
     TEST_SUCCESS(ITC_Id_split(&gpt_LeafId, &pt_OtherId));
+#else
+    TEST_IGNORE_MESSAGE("Extended API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 }
 
 /* Test failed normalisation of an ID is properly recovered from */
@@ -305,7 +314,7 @@ void ITC_Id_Test_normaliseIdIsRecoveredOnFailure(void)
 }
 
 /* Test failed summing of two IDs is properly cleaned up */
-void ITC_Id_Test_sumIdAreDestroyedOnFailure(void)
+void ITC_Id_Test_sumConstIdAreDestroyedOnFailure(void)
 {
     ITC_Id_t t_NewId1 = { 0 };
     ITC_Id_t *pt_NewId1 = &t_NewId1;
@@ -318,6 +327,8 @@ void ITC_Id_Test_sumIdAreDestroyedOnFailure(void)
     ITC_Id_t t_OtherIdRightChild = gt_LeftLeafOfParentId;
 
     ITC_Id_t *pt_OtherId = &t_OtherId;
+
+    ITC_Id_t *pt_ResultId;
 
     /* Fix pointers */
     t_OtherId.pt_Left = &t_OtherIdLeftChild;
@@ -350,7 +361,12 @@ void ITC_Id_Test_sumIdAreDestroyedOnFailure(void)
         ITC_STATUS_SUCCESS);
 
     /* Test summing the IDs */
-    TEST_FAILURE(ITC_Id_sum(&gpt_ParentId, &pt_OtherId), ITC_STATUS_FAILURE);
+    TEST_FAILURE(
+        ITC_Id_sumConst(
+            gpt_ParentId,
+            pt_OtherId,
+            &pt_ResultId),
+        ITC_STATUS_FAILURE);
 
     /* Setup expectations */
     ITC_Port_malloc_ExpectAndReturn(
@@ -378,15 +394,17 @@ void ITC_Id_Test_sumIdAreDestroyedOnFailure(void)
 
     /* Test summing the IDs the other way around */
     TEST_FAILURE(
-        ITC_Id_sum(
-            &pt_OtherId,
-            &gpt_ParentId),
+        ITC_Id_sumConst(
+            pt_OtherId,
+            gpt_ParentId,
+            &pt_ResultId),
         ITC_STATUS_FAILURE);
 }
 
 /* Test original IDs are destroyed when summed */
 void ITC_Id_Test_sumIdOriginalIdsAreDestroyedOnSuccess(void)
 {
+#if ITC_CONFIG_ENABLE_EXTENDED_API
     ITC_Id_t t_OtherId = gt_LeafNode;
     ITC_Id_t *pt_OtherId = &t_OtherId;
 
@@ -412,4 +430,7 @@ void ITC_Id_Test_sumIdOriginalIdsAreDestroyedOnSuccess(void)
     pt_OtherId->b_IsOwner = false;
     gpt_LeafId->b_IsOwner = true;
     TEST_SUCCESS(ITC_Id_sum(&gpt_LeafId, &pt_OtherId));
+#else
+    TEST_IGNORE_MESSAGE("Extended API support is disabled");
+#endif /* ITC_CONFIG_ENABLE_EXTENDED_API */
 }


### PR DESCRIPTION
Do not compile `ITC_Event_join`, `ITC_Id_sum` and `ITC_Id_split` when extened API support is disabled