### PR TITLE
Enforce strict max stack size usage during unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ highly dynamic number of replicas/processes in a distributed system.
 * Implements the full ITC mechanism as described in the research paper.
 * Written in C99. It has no dependencies apart from a few C standard library
   headers (`CMock` is only used for unit testing).
-* Minimises stack usage by **not** relying on recursion. The required stack size is `128B`.
+* Minimises stack usage by **not** relying on recursion. The required stack size is `<=144B`.
 * Generally tries to be as efficient and as small as possible.
 * Can be configured to use either 32 or 64-bit event counters.
 * Can be configured to use dynamic or static memory for the ITC node allocations,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ highly dynamic number of replicas/processes in a distributed system.
 * Implements the full ITC mechanism as described in the research paper.
 * Written in C99. It has no dependencies apart from a few C standard library
   headers (`CMock` is only used for unit testing).
-* Minimises stack usage by **not** relying on recursion.
+* Minimises stack usage by **not** relying on recursion. The required stack size is `128B`.
 * Generally tries to be as efficient and as small as possible.
 * Can be configured to use either 32 or 64-bit event counters.
 * Can be configured to use dynamic or static memory for the ITC node allocations,

--- a/libitc/meson.build
+++ b/libitc/meson.build
@@ -2,6 +2,14 @@ libitc_c_args = [
 
 ]
 
+if get_option('tests')
+    # Enforce strict max stack usage
+    # This is done to ensure the stack usage of the library is as low as
+    # possible, however, it is only enforced while unit testing, to ensure
+    # maximum compatibility with different systems and compilers.
+    libitc_c_args += '-Wstack-usage=128'
+endif
+
 libitc_link_args = [
 
 ]

--- a/libitc/meson.build
+++ b/libitc/meson.build
@@ -7,7 +7,7 @@ if get_option('tests')
     # This is done to ensure the stack usage of the library is as low as
     # possible, however, it is only enforced while unit testing, to ensure
     # maximum compatibility with different systems and compilers.
-    libitc_c_args += '-Wstack-usage=128'
+    libitc_c_args += '-Wstack-usage=144'
 endif
 
 libitc_link_args = [

--- a/libitc/meson.build
+++ b/libitc/meson.build
@@ -6,7 +6,8 @@ if get_option('tests')
     # Enforce strict max stack usage
     # This is done to ensure the stack usage of the library is as low as
     # possible, however, it is only enforced while unit testing, to ensure
-    # maximum compatibility with different systems and compilers.
+    # maximum compatibility with different systems, architectures, and
+    # compilers.
     libitc_c_args += '-Wstack-usage=144'
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -43,7 +43,6 @@ common_c_args = meson.get_compiler('c').get_supported_arguments([
     '-Wpointer-arith',
     '-Wshadow',
     '-Wshift-overflow=2',
-    # '-Wstack-usage=8192',
     '-Wstrict-prototypes',
     '-Wswitch-default',
     '-Wundef',


### PR DESCRIPTION
Adds `-Wstack-usage` when unit testing to ensure the library stack usage remains low.