### PR TITLE
Improve c and link arg compatibility

### DIFF
--- a/libitc/build/meson.build
+++ b/libitc/build/meson.build
@@ -3,8 +3,14 @@ libitc_lib = library(
     libitc_src,
     include_directories: [libitc_inc, libitc_pkg_inc],
     version: meson.project_version(),
-    c_args: libitc_c_args + common_c_args,
-    link_args: libitc_link_args + common_link_args,
+    c_args: meson.get_compiler('c').get_supported_arguments([
+        common_c_args,
+        libitc_c_args,
+    ]),
+    link_args: meson.get_compiler('c').get_supported_link_arguments([
+        common_link_args,
+        libitc_link_args,
+    ]),
     install: true,
     install_dir: libitc_install_dir,
     override_options: [

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ libitc_test_bin_install_dir = libitc_install_dir / 'tests'
 libitc_version_components = meson.project_version().split('.')
 
 # Common compiler args used with for all libs and executables
-common_c_args = meson.get_compiler('c').get_supported_arguments([
+common_c_args = [
     '-Wbidi-chars=any,ucn',
     '-Wcast-align',
     '-Wcast-qual',
@@ -52,12 +52,12 @@ common_c_args = meson.get_compiler('c').get_supported_arguments([
     '-DITC_VERSION_MAJOR=@0@'.format(libitc_version_components[0]),
     '-DITC_VERSION_MINOR=@0@'.format(libitc_version_components[1]),
     '-DITC_VERSION_PATCH=@0@'.format(libitc_version_components[2]),
-])
+]
 
 
 # Common link args used for all libs and executables
-common_link_args = meson.get_compiler('c').get_supported_link_arguments([
-])
+common_link_args = [
+]
 
 if get_option('tests')
     # Let the compiler know this is a unit test build

--- a/tests/build/meson.build
+++ b/tests/build/meson.build
@@ -53,8 +53,14 @@ libitc_test_exes_common_kwargs = {
         unity_dep,
         cmock_dep,
     ],
-    'c_args': libitc_test_c_args + common_c_args,
-    'link_args': libitc_test_link_args + common_link_args,
+    'c_args': meson.get_compiler('c').get_supported_arguments([
+        common_c_args,
+        libitc_test_c_args,
+    ]),
+    'link_args': meson.get_compiler('c').get_supported_link_arguments([
+        common_link_args,
+        libitc_test_link_args,
+    ]),
 }
 
 subdir('normal')


### PR DESCRIPTION
Improves the compatibility of c and link args by using the `get_supported_arguments` and `get_supported_link_arguments` functions right before they are passed as arguments to the `library` and `executable` functions. 