### PR TITLE
Allow configuration of output directories via the `libdir` and `bindir` options

### DIFF
--- a/libitc/build/meson.build
+++ b/libitc/build/meson.build
@@ -12,7 +12,6 @@ libitc_lib = library(
         libitc_link_args,
     ]),
     install: true,
-    install_dir: libitc_install_dir,
     override_options: [
         # Allow undefined symbols to exist
         # Used when compiling with static memory allocation support

--- a/meson.build
+++ b/meson.build
@@ -4,17 +4,13 @@ project('itc', 'c',
   license_files: ['LICENSE'],
   meson_version: '>=1.4.0',
   subproject_dir: 'vendor',
-  default_options : [
-        'prefix=' + meson.current_build_dir(),
-        'c_std=gnu99',
-        'default_library=both',
-        'werror=true',
-    ]
+  default_options : {
+        'prefix': meson.current_build_dir(),
+        'c_std': 'gnu99',
+        'default_library': 'both',
+        'werror': 'true',
+    }
 )
-
-# Install dirs
-libitc_install_dir = 'bin'
-libitc_test_bin_install_dir = libitc_install_dir / 'tests'
 
 libitc_version_components = meson.project_version().split('.')
 

--- a/tests/build/meson.build
+++ b/tests/build/meson.build
@@ -1,8 +1,5 @@
 fs = import('fs')
 
-libitc_normal_test_bin_install_dir = libitc_test_bin_install_dir / 'normal'
-libitc_mocked_test_bin_install_dir = libitc_test_bin_install_dir / 'mocked'
-
 # Entrypoint for the unit tests
 # Expects Unity to generate the unit test runner function
 libitc_test_entrypoint_file = '''/* The test runner function */

--- a/tests/build/mocked/meson.build
+++ b/tests/build/mocked/meson.build
@@ -64,7 +64,7 @@ foreach libitc_test_src_file_path : libitc_test_mocked_src
 
     # Generate the test executable
     libitc_test_exe = executable(
-        'Mocked' + libitc_test_src_name.replace('_', ''),
+        libitc_test_src_name.replace('_', '').replace('ITC', 'ITCMocked'),
         libitc_test_src_file_path,
         libitc_test_runner_ch_tgt,
         libitc_test_mock_ch_tgt,

--- a/tests/build/mocked/meson.build
+++ b/tests/build/mocked/meson.build
@@ -64,17 +64,16 @@ foreach libitc_test_src_file_path : libitc_test_mocked_src
 
     # Generate the test executable
     libitc_test_exe = executable(
-        libitc_test_src_name.replace('_', ''),
+        'Mocked' + libitc_test_src_name.replace('_', ''),
         libitc_test_src_file_path,
         libitc_test_runner_ch_tgt,
         libitc_test_mock_ch_tgt,
         libitc_test_exes_common_arg,
         install: true,
-        install_dir: libitc_mocked_test_bin_install_dir,
         # Add run path to LibITC that is relative to the binary location
         install_rpath: '$ORIGIN' / fs.relative_to(
-            get_option('prefix') / libitc_install_dir,
-            get_option('prefix') / libitc_mocked_test_bin_install_dir,
+            get_option('prefix') / get_option('libdir'),
+            get_option('prefix') / get_option('bindir'),
         ),
         kwargs: libitc_test_exes_common_kwargs
     )

--- a/tests/build/normal/meson.build
+++ b/tests/build/normal/meson.build
@@ -32,11 +32,10 @@ foreach libitc_test_src_file_path : libitc_test_normal_src
         libitc_test_runner_ch_tgt,
         libitc_test_exes_common_arg,
         install: true,
-        install_dir: libitc_normal_test_bin_install_dir,
         # Add run path to LibITC that is relative to the binary location
         install_rpath: '$ORIGIN' / fs.relative_to(
-            get_option('prefix') / libitc_install_dir,
-            get_option('prefix') / libitc_normal_test_bin_install_dir,
+            get_option('prefix') / get_option('libdir'),
+            get_option('prefix') / get_option('bindir'),
         ),
         kwargs: libitc_test_exes_common_kwargs
     )


### PR DESCRIPTION
Replaces the hardocded `install_dir` kwargs set  in `library()` and `executable()` calls for  `libdir` and `bindir` options.

This should improve compatibility and flexibilty on different systems and when used as a subproject.