### PR TITLE
Fix compilation errors with certain versions of GCC

### DIFF
--- a/libitc/ITC_SerDes_private.h
+++ b/libitc/ITC_SerDes_private.h
@@ -27,8 +27,9 @@
 
 /* Set a field in a serialised ITC node header */
 #define ITC_SERDES_HEADER_SET(t_Header, t_Field, t_Mask, t_Offset)             \
-  ((ITC_SerDes_Header_t)(((t_Header) & ~(t_Mask)) |                                                  \
-   ((((ITC_SerDes_Header_t)(t_Field)) << (t_Offset)) & (t_Mask))))
+    ((ITC_SerDes_Header_t)                                                     \
+        ((ITC_SerDes_Header_t)((t_Header) & ~(t_Mask)) |                       \
+         (((ITC_SerDes_Header_t)((t_Field) << (t_Offset))) & (t_Mask))))
 
 /* The header of a serialised leaf null ITC ID */
 #define ITC_SERDES_NULL_ID_HEADER                                        (0x00U)
@@ -95,8 +96,9 @@
 /** Create the header for a serialised ITC Event
  * @warning The `u8_CounterLen` must be `<= 15` */
 #define ITC_SERDES_CREATE_EVENT_HEADER(b_IsParent, u8_CounterLen)              \
-  ((ITC_SerDes_Header_t)(ITC_SERDES_EVENT_SET_IS_PARENT(0U, b_IsParent) |      \
-   ITC_SERDES_EVENT_SET_COUNTER_LEN(0U, u8_CounterLen)))
+    ((ITC_SerDes_Header_t)                                                     \
+     (ITC_SERDES_EVENT_SET_IS_PARENT(0U, b_IsParent) |                         \
+      ITC_SERDES_EVENT_SET_COUNTER_LEN(0U, u8_CounterLen)))
 
 /* The offset of the ID component len size in a serialised ITC Stamp header */
 #define ITC_SERDES_STAMP_ID_COMPONENT_LEN_OFFSET                            (0U)

--- a/libitc/ITC_SerDes_private.h
+++ b/libitc/ITC_SerDes_private.h
@@ -27,8 +27,8 @@
 
 /* Set a field in a serialised ITC node header */
 #define ITC_SERDES_HEADER_SET(t_Header, t_Field, t_Mask, t_Offset)             \
-  ((ITC_SerDes_Header_t)((t_Header) & ~(t_Mask)) |                                                  \
-   ((((ITC_SerDes_Header_t)(t_Field)) << (t_Offset)) & (t_Mask)))
+  ((ITC_SerDes_Header_t)(((t_Header) & ~(t_Mask)) |                                                  \
+   ((((ITC_SerDes_Header_t)(t_Field)) << (t_Offset)) & (t_Mask))))
 
 /* The header of a serialised leaf null ITC ID */
 #define ITC_SERDES_NULL_ID_HEADER                                        (0x00U)
@@ -95,10 +95,8 @@
 /** Create the header for a serialised ITC Event
  * @warning The `u8_CounterLen` must be `<= 15` */
 #define ITC_SERDES_CREATE_EVENT_HEADER(b_IsParent, u8_CounterLen)              \
-  ((ITC_SerDes_Header_t)ITC_SERDES_EVENT_SET_IS_PARENT(                        \
-       (ITC_SerDes_Header_t)0U, b_IsParent) |                                  \
-   ITC_SERDES_EVENT_SET_COUNTER_LEN(                                           \
-        (ITC_SerDes_Header_t)0U, u8_CounterLen))
+  ((ITC_SerDes_Header_t)(ITC_SERDES_EVENT_SET_IS_PARENT(0U, b_IsParent) |      \
+   ITC_SERDES_EVENT_SET_COUNTER_LEN(0U, u8_CounterLen)))
 
 /* The offset of the ID component len size in a serialised ITC Stamp header */
 #define ITC_SERDES_STAMP_ID_COMPONENT_LEN_OFFSET                            (0U)

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,11 @@ project('itc', 'c',
         'prefix': meson.current_build_dir(),
         'c_std': 'gnu99',
         'default_library': 'both',
-        'werror': 'true',
+        'werror': true,
+
+        # Turn off -Werror for cmock and unity
+        'cmock:werror': false,
+        'unity:werror': false,
     }
 )
 


### PR DESCRIPTION
Fix compilation errors when using GCC 10.2.1 (and possibly other versions).